### PR TITLE
cabal-install: 3.10 -> 3.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693953029,
-        "narHash": "sha256-1+28KQl4YC4IBzKo/epvEyK5KH4MlgoYueJ8YwLGbOc=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4077a0e4ac3356222bc1f0a070af7939c3098535",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,12 @@
 { pkgs ? import <nixpkgs> { } }:
 pkgs.mkShell {
   nativeBuildInputs = with pkgs.buildPackages; [
-    cabal-install
+    (haskell.lib.justStaticExecutables (haskellPackages.cabal-install))
     ghc
     ghcid
     haskell-language-server
-    haskellPackages.fourmolu_0_12_0_0
-    pkgconfig
+    (haskell.lib.dontCheck (haskellPackages.callHackage "fourmolu" "0.12.0.0" {}))
+    pkg-config
     zlib.dev
   ];
 }


### PR DESCRIPTION
This fixes a build error in the Cabal repo:

```
$ ./validate.sh -s build
=== build ==================================================================== 09:53:27 ===
=== Step Build: dry run ====================================================== 09:53:27 ===
cabal build -j4 -w ghc --builddir=dist-newstyle-validate-ghc-9.6.6 --project-file=cabal.validate.project Cabal Cabal-hooks cabal-testsuite Cabal-tests Cabal-QuickCheck Cabal-tree-diff Cabal-described cabal-install cabal-install-solver cabal-benchmarks --dry-run
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: cabal-testsuite-3 (user goal)
[__1] next goal: cabal-testsuite:setup.Cabal (dependency of cabal-testsuite)
[__1] rejecting: cabal-testsuite:setup.Cabal-3.13.0.0,
cabal-testsuite:setup.Cabal-3.12.1.0, cabal-testsuite:setup.Cabal-3.12.0.0
(constraint from maximum version of Cabal used by Setup.hs requires <3.12)
[__1] rejecting: cabal-testsuite:setup.Cabal-3.10.3.0/installed-3.10.3.0
(conflict: cabal-testsuite => cabal-testsuite:setup.Cabal^>=3.12.1)
[__1] skipping: cabal-testsuite:setup.Cabal-3.10.3.0,
cabal-testsuite:setup.Cabal-3.10.2.1, cabal-testsuite:setup.Cabal-3.10.2.0,
cabal-testsuite:setup.Cabal-3.10.1.0, cabal-testsuite:setup.Cabal-3.8.1.0,
cabal-testsuite:setup.Cabal-3.6.3.0, cabal-testsuite:setup.Cabal-3.6.2.0,
… [SNIP] …
cabal-testsuite:setup.Cabal-1.4.0.0, cabal-testsuite:setup.Cabal-1.2.4.0,
cabal-testsuite:setup.Cabal-1.2.3.0, cabal-testsuite:setup.Cabal-1.2.2.0,
cabal-testsuite:setup.Cabal-1.2.1, cabal-testsuite:setup.Cabal-1.1.6,
cabal-testsuite:setup.Cabal-1.24.1.0 (has the same characteristics that caused
the previous version to fail: excluded by constraint '^>=3.12.1' from
'cabal-testsuite')
[__1] fail (backjumping, conflict set: cabal-testsuite,
cabal-testsuite:setup.Cabal)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: cabal-testsuite:setup.Cabal,
cabal-testsuite
```